### PR TITLE
Limit results sent to client

### DIFF
--- a/client/routes.js
+++ b/client/routes.js
@@ -13,7 +13,7 @@ Router.route("/log/:repoName/:searchString(.*)?", {
 
   waitOn: function() {
     var params = this.params;
-    return Meteor.subscribe("changesets", params.repoName, params.searchString);
+    return Meteor.subscribe("changesets", params.repoName, params.searchString, params.query && parseInt(params.query.maxResults));
   },
 
   data: function() {

--- a/server/hg_log.js
+++ b/server/hg_log.js
@@ -32,7 +32,12 @@ HgLog.logResults = function(options) {
       return result.repo === options.repo;
     })
     .flatMap(function(result) {
-      return getLogs(result.repo, options.searchString);
+      var sequence = getLogs(result.repo, options.searchString);
+      if (options.maxResults) {
+        sequence = sequence.take(options.maxResults);
+      }
+
+      return sequence;
     });
 };
 

--- a/server/publications.js
+++ b/server/publications.js
@@ -1,6 +1,7 @@
-Meteor.publish("changesets", function(repoName, searchString) {
+Meteor.publish("changesets", function(repoName, searchString, maxResults) {
   check(repoName, String);
   check(searchString, Match.OneOf(String, undefined, null));
+  check(maxResults, Match.Optional(Match.Integer));
 
   var hg = Meteor.npmRequire("hg");
 
@@ -11,7 +12,8 @@ Meteor.publish("changesets", function(repoName, searchString) {
 
   var handle = HgLog.logResults({
       repo: fullRepoPath,
-      searchString: searchString
+      searchString: searchString,
+      maxResults: maxResults
     })
     .retry()
     .subscribe(function(entry) {


### PR DESCRIPTION
Add a query parameter, `maxResults`, that will be sent down to the server
on subscription. That will, in turn, limit the number of results
returned from the rx query.

However, right now this is only limiting the first batch of results. If
more results come in later, reactively, those will be added on top of
the limited results.
